### PR TITLE
Prefetch GitHub repositories on startup

### DIFF
--- a/project-resume-viewer/angular.json
+++ b/project-resume-viewer/angular.json
@@ -56,7 +56,13 @@
                   "maximumError": "8kB"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ]
             },
             "development": {
               "optimization": false,

--- a/project-resume-viewer/src/app/core/services/github.service.ts
+++ b/project-resume-viewer/src/app/core/services/github.service.ts
@@ -1,0 +1,91 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
+import { Observable, EMPTY, expand, map, reduce } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export interface Repo {
+  name: string;
+  html_url: string;
+  description: string | null;
+  language: string | null;
+  updated_at: string;
+  stargazers_count: number;
+  forks_count: number;
+  archived: boolean;
+  private: boolean;
+}
+
+interface PageResult {
+  repos: Repo[];
+  link: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class GithubService {
+  private readonly baseUrl = 'https://api.github.com';
+
+  constructor(private http: HttpClient) {}
+
+  private requestPage(username: string, page: number): Observable<PageResult> {
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+
+    if (environment.githubToken) {
+      headers['Authorization'] = `Bearer ${environment.githubToken}`;
+    }
+
+    return this.http
+      .get<Repo[]>(`${this.baseUrl}/users/${username}/repos`, {
+        observe: 'response',
+        headers: new HttpHeaders(headers),
+        params: {
+          per_page: 100,
+          page,
+          sort: 'updated',
+          direction: 'desc',
+        },
+      })
+      .pipe(
+        map((response: HttpResponse<Repo[]>) => ({
+          repos: response.body ?? [],
+          link: response.headers.get('Link'),
+        }))
+      );
+  }
+
+  fetchAllRepos(username: string): Observable<Repo[]> {
+    const getNextPage = (link: string | null): number | null => {
+      if (!link) return null;
+      const nextPart = link
+        .split(',')
+        .map((l) => l.trim())
+        .find((l) => l.endsWith('rel="next"'));
+      if (!nextPart) return null;
+      const match = nextPart.match(/<([^>]+)>/);
+      if (!match) return null;
+      try {
+        const url = new URL(match[1]);
+        const page = url.searchParams.get('page');
+        return page ? parseInt(page, 10) : null;
+      } catch {
+        return null;
+      }
+    };
+
+    return this.requestPage(username, 1).pipe(
+      expand((result) => {
+        const nextPage = getNextPage(result.link);
+        return nextPage ? this.requestPage(username, nextPage) : EMPTY;
+      }),
+      map((result) => result.repos),
+      reduce((acc, repos) => acc.concat(repos), [] as Repo[]),
+      map((repos) =>
+        repos.sort(
+          (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+        )
+      )
+    );
+  }
+}

--- a/project-resume-viewer/src/app/core/stores/repo.store.ts
+++ b/project-resume-viewer/src/app/core/stores/repo.store.ts
@@ -1,0 +1,28 @@
+import { Injectable, signal } from '@angular/core';
+import { GithubService, Repo } from '../services/github.service';
+import { environment } from '../../../environments/environment';
+import { firstValueFrom } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class RepoStore {
+  readonly repos = signal<Repo[]>([]);
+  readonly loading = signal<boolean>(false);
+  readonly error = signal<string | null>(null);
+
+  constructor(private githubService: GithubService) {}
+
+  async prefetch(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const repos = await firstValueFrom(
+        this.githubService.fetchAllRepos(environment.githubUsername)
+      );
+      this.repos.set(repos);
+    } catch (err: any) {
+      this.error.set(err?.message ?? 'Failed to load repositories');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/project-resume-viewer/src/app/features/home/pages/home-page/home-page.component.html
+++ b/project-resume-viewer/src/app/features/home/pages/home-page/home-page.component.html
@@ -4,14 +4,25 @@
     I’m a software developer specializing in C#/.NET and Angular. Passionate about building scalable web apps and exploring new technologies.
   </p>
 
+  <a class="cv-button" href="assets/resume.pdf" target="_blank" rel="noopener">📄 View CV</a>
+
   <section class="projects">
     <h2>My Projects</h2>
-    <ul>
-      <li *ngFor="let repo of repos$ | async">
-        <a [href]="repo.html_url" target="_blank" rel="noopener noreferrer">{{ repo.name }}</a>
-      </li>
-    </ul>
+    <div *ngIf="loading(); else loaded">
+      <p>Loading repositories...</p>
+    </div>
+    <ng-template #loaded>
+      <p *ngIf="error()">{{ error() }}</p>
+      <ul *ngIf="!error()">
+        <li *ngFor="let repo of repos()">
+          <a [href]="repo.html_url" target="_blank" rel="noopener noreferrer">{{ repo.name }}</a>
+          <p class="description">{{ repo.description || 'No description' }}</p>
+          <p class="meta">
+            <span class="language">{{ repo.language || 'Unknown' }}</span>
+            <span class="updated">{{ repo.updated_at | date: 'mediumDate' }}</span>
+          </p>
+        </li>
+      </ul>
+    </ng-template>
   </section>
-
-  <a class="cv-button" href="assets/resume.pdf" target="_blank" rel="noopener">View CV</a>
 </div>

--- a/project-resume-viewer/src/app/features/home/pages/home-page/home-page.component.scss
+++ b/project-resume-viewer/src/app/features/home/pages/home-page/home-page.component.scss
@@ -16,20 +16,41 @@
 .projects ul {
   list-style: none;
   padding: 0;
+  display: grid;
+  gap: 1rem;
 }
 
 .projects li {
-  margin: 0.5rem 0;
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  text-align: left;
+  transition: box-shadow 0.3s;
+}
+
+.projects li:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .projects a {
   color: #007acc;
   text-decoration: none;
-  transition: color 0.3s;
+  font-weight: 600;
 }
 
 .projects a:hover {
   text-decoration: underline;
+}
+
+.description {
+  margin: 0.5rem 0;
+}
+
+.meta {
+  font-size: 0.875rem;
+  color: #555;
+  display: flex;
+  justify-content: space-between;
 }
 
 .cv-button {

--- a/project-resume-viewer/src/app/features/home/pages/home-page/home-page.component.ts
+++ b/project-resume-viewer/src/app/features/home/pages/home-page/home-page.component.ts
@@ -1,13 +1,6 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
-import { map } from 'rxjs';
-
-interface Repo {
-  name: string;
-  html_url: string;
-  private: boolean;
-}
+import { RepoStore } from '../../../../core/stores/repo.store';
 
 @Component({
   selector: 'app-home-page',
@@ -17,15 +10,11 @@ interface Repo {
   styleUrl: './home-page.component.scss'
 })
 export class HomePageComponent {
-  private readonly http = inject(HttpClient);
+  private readonly repoStore = inject(RepoStore);
 
-  readonly repos$ = this.http
-    .get<Repo[]>(`https://api.github.com/users/your-username/repos`)
-    .pipe(
-      map(repos =>
-        repos
-          .filter(repo => !repo.private)
-          .sort((a, b) => a.name.localeCompare(b.name))
-      )
-    );
+  readonly repos = computed(() =>
+    this.repoStore.repos().filter((repo) => !repo.archived)
+  );
+  readonly loading = this.repoStore.loading;
+  readonly error = this.repoStore.error;
 }

--- a/project-resume-viewer/src/environments/environment.prod.ts
+++ b/project-resume-viewer/src/environments/environment.prod.ts
@@ -1,0 +1,5 @@
+export const environment = {
+  production: true,
+  githubUsername: 'your-username',
+  githubToken: undefined as string | undefined
+};

--- a/project-resume-viewer/src/environments/environment.ts
+++ b/project-resume-viewer/src/environments/environment.ts
@@ -1,0 +1,5 @@
+export const environment = {
+  production: false,
+  githubUsername: 'your-username',
+  githubToken: undefined as string | undefined
+};

--- a/project-resume-viewer/src/main.ts
+++ b/project-resume-viewer/src/main.ts
@@ -1,13 +1,20 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { importProvidersFrom } from '@angular/core';
+import { APP_INITIALIZER } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { HttpClientModule } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
 import { App } from './app/app';
 import { routes } from './app/app.routes';
+import { RepoStore } from './app/core/stores/repo.store';
 
 bootstrapApplication(App, {
   providers: [
     provideRouter(routes),
-    importProvidersFrom(HttpClientModule)
+    provideHttpClient(),
+    {
+      provide: APP_INITIALIZER,
+      multi: true,
+      deps: [RepoStore],
+      useFactory: (repoStore: RepoStore) => () => repoStore.prefetch()
+    }
   ]
-}).catch(err => console.error(err));
+}).catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- bootstrap the Angular app with router, HTTP client, and APP_INITIALIZER to prefetch repositories
- add GitHub service and signal-based store to load and cache repos from the configured username
- implement a new home page that lists non-archived repos with loading and error states, description, language, and last-updated info

## Testing
- `npm run build`
- `npm test -- --watch=false` *(fails: Cannot find module '@angular-devkit/build-angular/plugins/karma')*
- `npm install --save-dev @angular-devkit/build-angular` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5aa558e14832f8964dadccaaedf4d